### PR TITLE
Game relation schema update

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,4 +24,14 @@ class ApplicationController < ActionController::Base
       end
     end
   end
+
+  # This needs to be fixed if user is not logged in
+  def current_game
+    if current_user.nil?
+      #Show the last game being run?
+      @game = Game.last
+    else
+      @game = current_user.game
+    end
+  end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,21 +1,31 @@
 class GamesController < ApplicationController
-before_action :authenticate_user!, except:[:dashboard]
-before_action :authenticate_control!, except:[:dashboard]
+  before_action :authenticate_user!, except:[:dashboard]
+  before_action :authenticate_control!, except:[:dashboard]
 
   # Main Dashboard for All Players
   def dashboard
-    @game = Game.last.update
+    @game = current_game
     @data = @game.data
   end
 
   # Human Control dashboard to quickly see PR's
   def human_control
-    @last_round = (Game.last.round) -1
-    
-    @pr_amounts = PublicRelation.where(round: @last_round).group(:country).sum(:pr_amount)
-    @current_round = Game.last.round
-    @public_relations = PublicRelation.all.order(round: :desc, created_at: :desc)
+    @game = current_game
+    @last_round = (@game.round) -1
+
+    @pr_amounts = @game.public_relations
+      .where(round: @last_round)
+      .group(:country)
+      .sum(:pr_amount)
+
+    @current_round = @game.round
+    @public_relations = @game.public_relations.order(
+                                                  round: :desc,
+                                                  created_at: :desc
+                                                )
     @countries = Game::COUNTRIES
+
+    #To Do: Move income values into stored structure somewhere
     @income_values = {}
     @income_values['Brazil'] =[2,5,6,7,8,9,10,11,12]
     @income_values['China']= [2,3,5,7,9,10,12,14,16]
@@ -25,9 +35,10 @@ before_action :authenticate_control!, except:[:dashboard]
     @income_values['Russian Federation'] = [2,4,5,6,7,8,9,10,11]
     @income_values['United Kingdom'] =[2,4,6,7,8,9,10,11,12]
     @income_values['USA']= [1,3,5,7,9,11,13,15,17]
-    @incomes = Income.where(round: @current_round)
+
+    @incomes = @game.incomes.where(round: @current_round)
     if @last_round > 0
-      @previous_income = Income.where(round: @last_round)
+      @previous_income = @game.incomes.where(round: @last_round)
     end
   end
 
@@ -62,6 +73,7 @@ before_action :authenticate_control!, except:[:dashboard]
       pr.save
       results.push(pr)
     end
+    current_game.incomes.push(results)
     respond_to do |format|
       format.html{redirect_to human_control_path, notice: "Entered in #{results.length} for Round: #{round}."}
     end
@@ -70,20 +82,20 @@ before_action :authenticate_control!, except:[:dashboard]
 
   # Administrative stuff for Kevin
   def admin_control
-    @game = Game.last
+    @game = current_game
     @time = @game.next_round.in_time_zone(@game.time_zone)
     render 'admin'
   end
 
   def update_control_message
-    @game = Game.last
+    @game = current_game
     @game.control_message = params[:game][:control_message]
     @game.save
     redirect_to admin_control_path
   end
 
   def update_rioters
-    @game = Game.last
+    @game = current_game
     data = @game.data
     data['rioters'] = params[:game][:rioters]
     @game.data = data
@@ -92,7 +104,7 @@ before_action :authenticate_control!, except:[:dashboard]
   end
 
   def update_round
-    @game = Game.last
+    @game = current_game
     @game.round = params[:game][:round]
     @game.save
     redirect_to admin_control_path
@@ -100,22 +112,29 @@ before_action :authenticate_control!, except:[:dashboard]
 
   # Post
   def reset
-    Game.last.reset
-    g = Game.last
-    Tweet.delete_all
-    NewsMessage.delete_all
-    PublicRelation.delete_all
-    TerrorTracker.delete_all
-    t = TerrorTracker.create(
-      description: "Initial Terror",
-      amount: 50,
-      round: g.round
+    current_game.reset
+    g = current_game
+    g.tweets.delete_all
+    g.tweets.news_messages.delete_all
+    g.public_relations.delete_all
+    g.terror_trackers.delete_all
+    g.terror_tracker.push(
+      TerrorTracker.create(
+        description: "Initial Terror",
+        amount: 50,
+        round: g.round
+      )
     )
+
+    g.incomes.delete_all
+    Game::COUNTRIES.each do |country|
+      g.incomes.push(Income.create(round: g.round, team_name: country, amount: 6))
+    end
   end
 
   # Post
   def toggle_game_status
-    @game = Game.last
+    @game = current_game
     data = @game.data
     # if game is not paused, then add 5 to clock
     unless data['paused']
@@ -129,7 +148,7 @@ before_action :authenticate_control!, except:[:dashboard]
 
   # Post
   def toggle_alien_comms
-    @game = Game.last
+    @game = current_game
     data = @game.data
     data['alien_comms'] = !data['alien_comms']
     @game.data = data
@@ -142,9 +161,9 @@ before_action :authenticate_control!, except:[:dashboard]
     @game = Game.find(params[:id])
     dateObj = params["game"]
     # Assumes local server time is the time and then converts to utc
-    datetime = Time.zone.local(dateObj["next_round(1i)"].to_i, dateObj["next_round(2i)"].to_i, 
-                        dateObj["next_round(3i)"].to_i, dateObj["next_round(4i)"].to_i,
-                        dateObj["next_round(5i)"].to_i).utc()
+    datetime = Time.zone.local(dateObj["next_round(1i)"].to_i, dateObj["next_round(2i)"].to_i,
+                               dateObj["next_round(3i)"].to_i, dateObj["next_round(4i)"].to_i,
+                               dateObj["next_round(5i)"].to_i).utc()
     @game.next_round = datetime
     @game.time_zone = dateObj["time_zone"]
     @game.save
@@ -165,8 +184,8 @@ before_action :authenticate_control!, except:[:dashboard]
     end
   end
 
-private
+  private
   def game_params
-      params[:game].permit(:next_round)
+    params[:game].permit(:next_round)
   end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,6 +1,6 @@
 class GamesController < ApplicationController
-  before_action :authenticate_user!, except:[:dashboard]
-  before_action :authenticate_control!, except:[:dashboard]
+ before_action :authenticate_user!, except:[:dashboard]
+ before_action :authenticate_control!, except:[:dashboard]
 
   # Main Dashboard for All Players
   def dashboard

--- a/app/controllers/incomes_controller.rb
+++ b/app/controllers/incomes_controller.rb
@@ -16,7 +16,7 @@ class IncomesController < ApplicationController
 
   # GET /incomes/new
   def new
-    @round = Game.last.round
+    @round = current_game.round
     @countries = Game::COUNTRIES
     @income = Income.new
   end
@@ -34,6 +34,7 @@ class IncomesController < ApplicationController
 
     respond_to do |format|
       if @income.save
+        current_game.push(@income)
         format.html { redirect_to @income, notice: 'Income was successfully created.' }
         format.json { render :show, status: :created, location: @income }
       else

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -28,9 +28,9 @@ class MessagesController < ApplicationController
 
 	def create
 		@message = Message.new(message_params)
-		#Is asking for the first element in Game is the best/correct way to get the current game?
-		@message.round_number = Game.last.round
-		@message.game_id = Game.last.id
+		@game = current_game
+		@message.round_number = @game.round
+		@message.game_id = @game.id
 
 		if @message.save
 			redirect_to '/messages'

--- a/app/controllers/news_messages_controller.rb
+++ b/app/controllers/news_messages_controller.rb
@@ -5,7 +5,7 @@ class NewsMessagesController < ApplicationController
   # GET /news_messages
   # GET /news_messages.json
   def index
-    @current_round = Game.last.round
+    @current_round = current_game.round
     @news_messages = NewsMessage.all.order(round: :desc, created_at: :desc)
     @papers = NewsMessage.uniq.pluck(:round).sort
   end
@@ -17,7 +17,7 @@ class NewsMessagesController < ApplicationController
 
   # GET /news_messages/new
   def new
-    @current_round = Game.last.round
+    @current_round = current_game.round
     @news_message = NewsMessage.new
     @news_message.visible_content = true
   end
@@ -34,7 +34,7 @@ class NewsMessagesController < ApplicationController
     if @news_message.title.nil?
       @news_message.title = "AP Reports:"
     end
-    @current_round = Game.last.round
+    @current_round = current_game.round
     if params[:post_online]
       client = Tweet.generate_client
       client.update("AP: #{@news_message.content}")
@@ -42,6 +42,7 @@ class NewsMessagesController < ApplicationController
 
     respond_to do |format|
       if @news_message.save
+        current_game.news_messages.push(@news_message)
         format.html { redirect_to @news_message, notice: 'News message was successfully created.' }
         format.json { render :show, status: :created, location: @news_message }
       else
@@ -114,7 +115,7 @@ class NewsMessagesController < ApplicationController
   end
 
   def hide_all_media
-    @round = Game.last.round - 1
+    @round = current_game.round - 1
     @news = NewsMessage.where(round: @round)
     @news.update_all(visible_image: false)
     redirect_to news_messages_path, notice: "Made all news invisible."

--- a/app/controllers/news_players_controller.rb
+++ b/app/controllers/news_players_controller.rb
@@ -3,7 +3,7 @@ class NewsPlayersController < ApplicationController
   # GET /news_messages
   # GET /news_messages.json
   def index
-    @current_round = Game.last.round
+    @current_round = current_game.round
     @news_messages = NewsMessage.all.order(round: :desc, created_at: :desc)
     @papers = NewsMessage.uniq.pluck(:round).sort
   end

--- a/app/controllers/public_relations_controller.rb
+++ b/app/controllers/public_relations_controller.rb
@@ -6,7 +6,7 @@ class PublicRelationsController < ApplicationController
   def un_dashboard
     @public_relations = PublicRelation.all.order(round: :desc, created_at: :desc)
     @countries = Game::COUNTRIES
-    @current_round = Game.last.round
+    @current_round = current_game.round
   end
 
   # Post
@@ -46,6 +46,7 @@ class PublicRelationsController < ApplicationController
       pr.save
       results.push(pr)
     end
+    current_game.public_relations.push(results)
     redirect_to un_dashboard_path
   end
 
@@ -53,7 +54,7 @@ class PublicRelationsController < ApplicationController
   def country_status
     @country = params[:country]
     @countries = Game::COUNTRIES
-    @game = Game.last
+    @game = current_game
     if Game::COUNTRIES.any?{|x| x ==@country}
       @public_relations = PublicRelation.order(round: :desc, created_at: :desc).where country: @country
       # UN control needs to know amount of PR per group by type
@@ -83,7 +84,7 @@ class PublicRelationsController < ApplicationController
   def new
     @public_relation = PublicRelation.new
     @countries = Game::COUNTRIES
-    @current_round = Game.last.round
+    @current_round = current_game.round
   end
 
   # GET /public_relations/1/edit
@@ -99,6 +100,7 @@ class PublicRelationsController < ApplicationController
 
     respond_to do |format|
       if @public_relation.save
+        current_game.public_relations.push(@public_relation)
         format.html { redirect_to @public_relation, notice: 'Public relation was successfully created.' }
         format.json { render :show, status: :created, location: @public_relation }
       else

--- a/app/controllers/terror_trackers_controller.rb
+++ b/app/controllers/terror_trackers_controller.rb
@@ -4,7 +4,7 @@ class TerrorTrackersController < ApplicationController
   before_action :authenticate_control!
   # Patch
   def update_activity
-    @game = Game.last
+    @game = current_game
     @game.activity = params[:game][:activity]
     @game.save
     redirect_to terror_trackers_path
@@ -14,13 +14,13 @@ class TerrorTrackersController < ApplicationController
   # GET /terror_trackers
   # GET /terror_trackers.json
   def index
-    @game = Game.last
+    @game = current_game
     @terror_trackers = TerrorTracker.all.order(created_at: :desc)
     @tcount = TerrorTracker.sum(:amount)
 
     # Requirements for a new terror tracker event
     @terror_tracker = TerrorTracker.new
-    @current_round = Game.last.round
+    @current_round = current_game.round
 
   end
 
@@ -32,7 +32,7 @@ class TerrorTrackersController < ApplicationController
   # GET /terror_trackers/new
   def new
     @terror_tracker = TerrorTracker.new
-    @current_round = Game.last.round
+    @current_round = current_game.round
   end
 
   # GET /terror_trackers/1/edit
@@ -47,6 +47,7 @@ class TerrorTrackersController < ApplicationController
 
     respond_to do |format|
       if @terror_tracker.save
+        current_game.terror_trackers.push(@terror_tracker)
         format.html { redirect_to terror_trackers_path, notice: 'Terror tracker was successfully created.' }
         format.json { render :show, status: :created, location: @terror_tracker }
       else

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,4 +1,11 @@
 class Game < ActiveRecord::Base
+  has_many :incomes
+  has_many :messages
+  has_many :news_messages
+  has_many :public_relations
+  has_many :terror_trackers
+  has_many :tweets
+
   serialize :game_data, JSON
   COUNTRIES = ['Brazil', 'China', 'France', 'India', 'Japan', 'Russian Federation','United Kingdom', 'USA']
   def reset()

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -5,6 +5,7 @@ class Game < ActiveRecord::Base
   has_many :public_relations
   has_many :terror_trackers
   has_many :tweets
+  has_many :users
 
   serialize :game_data, JSON
   COUNTRIES = ['Brazil', 'China', 'France', 'India', 'Japan', 'Russian Federation','United Kingdom', 'USA']

--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -1,2 +1,3 @@
 class Income < ActiveRecord::Base
+  belongs_to :game
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,2 +1,3 @@
 class Message < ActiveRecord::Base
+  belongs_to :game
 end

--- a/app/models/news_message.rb
+++ b/app/models/news_message.rb
@@ -1,5 +1,5 @@
 class NewsMessage < ActiveRecord::Base
-  
+  belongs_to :game
   # Get all newsfor a given round
   def self.round_news(round)
     NewsMessage.where(round: round)

--- a/app/models/public_relation.rb
+++ b/app/models/public_relation.rb
@@ -1,5 +1,6 @@
 class PublicRelation < ActiveRecord::Base
-  
+  belongs_to :game
+
   VALID_SOURCES = ['','Rioters', 'UN Crisis', 'Alien Agent', 'Terror', 'Human Operative', 'Sabotage', 
       'UN Bonus', 'News', 'Player Spending', 'Other', 'Tech']
 

--- a/app/models/terror_tracker.rb
+++ b/app/models/terror_tracker.rb
@@ -1,5 +1,5 @@
 class TerrorTracker < ActiveRecord::Base
-
+  belongs_to :game
   # Get all the Terror accumulated
   def self.totalTerror
     TerrorTracker.sum(:amount)

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,6 +1,7 @@
 
 class Tweet < ActiveRecord::Base
   # https://github.com/sferik/twitter
+  belongs_to :game
 
   def publish(client)
     require 'open-uri'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ActiveRecord::Base
   CONTROL_ROLES = ["SuperAdmin","Admin","Control"]
   PLAYER_ROLES = ["Head of State"]
+  belongs_to :game
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/views/games/admin.html.erb
+++ b/app/views/games/admin.html.erb
@@ -39,7 +39,7 @@
   <h3>Advanced Controls</h3>
   <section>
     <ul>
-      <li><p>Current time is: <%= @time %></p>
+      <li><p>Next round is at: <%= @time %></p>
         <p>Current time zone is: <%= @game.time_zone %></p>
         <%= form_for(@game, url: update_time_path(@game)) do |f|%>
           <%= Time.use_zone(@game.time_zone) do %>

--- a/db/migrate/20160307043720_add_game_references.rb
+++ b/db/migrate/20160307043720_add_game_references.rb
@@ -1,0 +1,15 @@
+class AddGameReferences < ActiveRecord::Migration
+  def change
+    add_reference :public_relations, :game, index: true
+    add_foreign_key :public_relations, :games
+
+    add_reference :terror_trackers, :game, index: true
+    add_foreign_key :terror_trackers, :games
+
+    add_reference :incomes, :game, index: true
+    add_foreign_key :incomes, :games
+
+    add_reference :tweets, :game, index: true
+    add_foreign_key :tweets, :games
+  end
+end

--- a/db/migrate/20160320220659_add_game_to_user.rb
+++ b/db/migrate/20160320220659_add_game_to_user.rb
@@ -1,0 +1,6 @@
+class AddGameToUser < ActiveRecord::Migration
+  def change
+    add_reference :users, :game, index: true
+    add_foreign_key :users, :games
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160218012937) do
+ActiveRecord::Schema.define(version: 20160307043720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,7 +26,7 @@ ActiveRecord::Schema.define(version: 20160218012937) do
     t.datetime "updated_at"
     t.string   "control_message"
     t.string   "activity"
-    t.string   "time_zone",       limit: 255, default: "UTC"
+    t.string   "time_zone",       limit: 255, default: "Pacific Time (US & Canada)"
   end
 
   create_table "incomes", force: :cascade do |t|
@@ -35,7 +35,10 @@ ActiveRecord::Schema.define(version: 20160218012937) do
     t.integer  "round"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "game_id"
   end
+
+  add_index "incomes", ["game_id"], name: "index_incomes_on_game_id", using: :btree
 
   create_table "messages", force: :cascade do |t|
     t.string   "sender"
@@ -68,7 +71,10 @@ ActiveRecord::Schema.define(version: 20160218012937) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "source"
+    t.integer  "game_id"
   end
+
+  add_index "public_relations", ["game_id"], name: "index_public_relations_on_game_id", using: :btree
 
   create_table "terror_trackers", force: :cascade do |t|
     t.string   "description"
@@ -76,7 +82,10 @@ ActiveRecord::Schema.define(version: 20160218012937) do
     t.integer  "round"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.integer  "game_id"
   end
+
+  add_index "terror_trackers", ["game_id"], name: "index_terror_trackers_on_game_id", using: :btree
 
   create_table "tweets", force: :cascade do |t|
     t.string   "twitter_name"
@@ -88,7 +97,10 @@ ActiveRecord::Schema.define(version: 20160218012937) do
     t.datetime "tweet_time"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "game_id"
   end
+
+  add_index "tweets", ["game_id"], name: "index_tweets_on_game_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                              default: "",                           null: false
@@ -110,4 +122,8 @@ ActiveRecord::Schema.define(version: 20160218012937) do
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "incomes", "games"
+  add_foreign_key "public_relations", "games"
+  add_foreign_key "terror_trackers", "games"
+  add_foreign_key "tweets", "games"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160307043720) do
+ActiveRecord::Schema.define(version: 20160320220659) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -117,13 +117,16 @@ ActiveRecord::Schema.define(version: 20160307043720) do
     t.datetime "updated_at"
     t.string   "role"
     t.string   "time_zone",              limit: 255, default: "Pacific Time (US & Canada)"
+    t.integer  "game_id"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["game_id"], name: "index_users_on_game_id", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
   add_foreign_key "incomes", "games"
   add_foreign_key "public_relations", "games"
   add_foreign_key "terror_trackers", "games"
   add_foreign_key "tweets", "games"
+  add_foreign_key "users", "games"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,15 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-g = Game.create(
+# Create User
+u = User.create(role: "SuperAdmin")
+u.email = "wts@wts.com"
+u.password='swordfish'
+u.password_confirmation='swordfish'
+u.save
+
+# Create the user's game
+u.game= Game.create(
   name: "Watch the Skies Test",
   round: 0,
   control_message: "Welcome",
@@ -18,56 +26,54 @@ g = Game.create(
     paused: true,
     }
 )
+u.save
+
+# Hold on to reference to the game
+game = u.game
 
 #An example message for the database. Probably doesn't need to exist in the final version.
-m = Message.create(
-	sender: "UK",
-	recipient: "France",
-	content: "This is an example message",
-	round_number: 0,
-	game_id: g.id
-)
+# m = Message.create(
+# 	sender: "UK",
+# 	recipient: "France",
+# 	content: "This is an example message",
+# 	round_number: 0,
+# 	game_id: g.id
+# )
 
 # create initial Terror Item
-t = TerrorTracker.create(
+game.terror_trackers.push(TerrorTracker.create(
   description: "Initial Terror",
   amount: 50,
-  round: g.round
-  )
+  round: game.round
+  ))
 
 # Create some news message stuff
-NewsMessage.create(
+game.news_messages.push(NewsMessage.create(
   title: "Daily Earth News reports:",
   content: "DEN reported some things",
-  round: 0,
+  round: game.round,
   visible_content:true,
   visible_image:true,
   media_url: "http://megagamesociety.com/images/mainlogo.png"
-  )
+  ))
 
-NewsMessage.create(
+game.news_messages.push(NewsMessage.create(
   title: "Global News Network reports:",
   content: "GNN also reported some things.",
-  round: 0,
+  round: game.round,
   visible_content: true,
   visible_image: true
-  )
+  ))
 
-NewsMessage.create(
+game.news_messages.push(NewsMessage.create(
   title: "Science & Financial Times reports:",
   content: "Science & Financial Times reported some stuff.",
-  round: 0,
+  round: game.round,
   visible_content:true,
   visible_image: true
-  )
-
-u = User.create(role: "SuperAdmin")
-u.email = "wts@wts.com"
-u.password='swordfish'
-u.password_confirmation='swordfish'
-u.save
+  ))
 
 # Income starts at 6
 Game::COUNTRIES.each do |country|
-  Income.create(round: 0, team_name: country, amount: 6)
+  game.incomes.push(Income.create(round: game.round, team_name: country, amount: 6))
 end


### PR DESCRIPTION
This PR governs all the changes required to allow multiple games of Watch the Skies to run concurrently.

In particular, the PR covers all of the base migrations and relations that need to be set up.

Please note this will cause significant changes to the database.  Data preservation was not a goal so I would recommend wiping out your database and re-seeding with updated seed file.

Now, every table should relate back to a game.  Users will also have to be tied to a game.

If you are working on a controller, you can use the application_controller method `current_game` in order to fetch the game the user is to assigned to.  If the user does not have a game, it defaults to the last game.  However this is behavior that will probably change soon as all users should be assigned to a game or not have access to most of the app.

Other things still in the process (but might be put into this PR) would be user registration, assigning users to games via admin/ upgrading users as SuperAdmin, and a main splash page (since the dashboard itself is no longer is relevant as the main page).  However parts of this PR is a blocker for others and so I'm opening it now for review.