### PR TITLE
Fix dashboard css

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -93,10 +93,10 @@ body {
   background: $background;
   color: $black;
   font-family: verdana, arial, helvetica, sans-serif;
-  font-size: 2.5rem;
+  font-size: 1.4rem;
   height: 100%;
   min-height: 100%;
-  line-height: 3.3rem;
+  line-height: 2.1rem;
   margin: 0;
   padding: 0 0 50px 0;
 }
@@ -125,19 +125,19 @@ body {
 .DEN {
   color: black;
   font-family: "Comic Sans MS";
-  font-size: 1.6rem;
+  font-size: 1.4rem;
 }
 
 .GNN {
   color: black;
   font-family: "Arial";
-  font-size: 1.6rem;
+  font-size: 1.4rem;
 }
 
 .SFT {
   color: black;
   font-family: "Times New Roman";
-  font-size: 1.6rem;
+  font-size: 1.4rem;
 }
 
 
@@ -153,10 +153,11 @@ h1, h2, h3, h4, h5, h6 {
 
 // Let's avoid using less than an h4 - Our fonts will be larger since
 // we're taking a Tablet-First approach.
-h1 { font-size: 5.6rem; line-height: 6.4rem; }
-h2 { font-size: 3.6rem; line-height: 4.4rem; }
-h3 { font-size: 2.8rem; line-height: 3.6rem; }
-h4 { font-size: 2.5rem; line-height: 3.3rem; }
+h1 { font-size: 3.75rem; line-height: 4.25rem; }
+h2 { font-size: 3.5rem; line-height: 4rem; }
+h3 { font-size: 3.25rem; line-height: 3.75rem; }
+h4 { font-size: 2.25rem; line-height: 2.75rem; }
+
 
 h2, h3 {
   color: $green;
@@ -173,8 +174,8 @@ h4 {
 }
 
 p, ul {
-  font-size: 2.5rem;
-  line-height: 3.3rem;
+  font-size: 1.4rem;
+  line-height: 2rem;
   margin: 0;
 }
 
@@ -259,7 +260,7 @@ input {
   background-color: $white;
   border: 1px solid $border-grey;
   color: $black;
-  font-size: 2rem;
+  font-size: 1.4rem;
   height: 40px;
   padding: 0 20px;
 }
@@ -280,7 +281,7 @@ textarea {
   background-color: $white;
   border: 1px solid $border-grey;
   color: $black;
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   padding: 5px;
   resize: vertical;
   width: 100%;
@@ -292,8 +293,7 @@ textarea {
   cursor: pointer;
   display: inline-block;
   font-style: italic;
-  font-size: 2rem;
-  height: 40px;
+  font-size: 1.4rem;
   line-height: 3.8rem;
   margin: 5px 0;
   padding: 0 20px;
@@ -332,7 +332,7 @@ textarea {
 table {
   border-collapse: collapse;
   border-spacing: 0;
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   line-height: 2.4rem;
   margin: 10px 0;
   width: 100%;
@@ -355,7 +355,7 @@ table {
   }
 
   td {
-    font-size: 1.6rem;
+    font-size: 1.4rem;
     line-height: 2.4rem;
     padding: 10px;
     vertical-align: middle;
@@ -368,12 +368,12 @@ table {
   .controls {
     .button-input {
       margin: 5px 0;
-      width: 105px;
+      width: 130px;
     }
   }
 
   .button-input {
-    font-size: 1.6rem;
+    font-size: 1.4rem;
     margin: 0;
   }
 }

--- a/app/assets/stylesheets/games.css.scss
+++ b/app/assets/stylesheets/games.css.scss
@@ -73,19 +73,24 @@ $terror-red: #BD2C00;
   background-position: top center;
   background-repeat: repeat-x;
   background-size: contain;
-  font-size: 5rem;
-  line-height: 5.8rem;
+  font-size: 3.125rem;
+  line-height: 3.625rem;
   padding-bottom: 0px;
   padding-top: 20px;
 
+  h2 {
+    font-size: 2.25rem;
+    line-height: 2.75rem;
+  }
+
   h3 {
-    font-size: 6rem;
-    line-height: 6.8rem;
+    font-size: 3.75rem;
+    line-height: 4.25rem;
   }
 
   h4 {
-    font-size: 5.2rem;
-    line-height: 6rem;
+    font-size: 3.25rem;
+    line-height: 3.75rem;
   }
 }
 
@@ -182,8 +187,8 @@ $terror-red: #BD2C00;
   vertical-align: top;
 
   p {
-    font-size: 5.8rem;
-    line-height: 6.6rem;
+    font-size: 3.625rem;
+    line-height: 4.125rem;
     margin: 0;
     text-transform: uppercase;
   }
@@ -205,7 +210,7 @@ $terror-red: #BD2C00;
     border-right: 15px;
     color: #FFF;
     display: inline-block;
-    font-size: 6rem;
+    font-size: 3.75rem;
     margin: 0;
     padding: 0 15px;
 
@@ -227,7 +232,7 @@ $terror-red: #BD2C00;
   }
 
   .glyphicon {
-    font-size: 6rem;
+    font-size: 3.75rem;
     top: 7px;
   }
 
@@ -275,7 +280,7 @@ $terror-red: #BD2C00;
   .news-time {
     display: inline-block;
     float: left;
-    font-size: 5.2rem;
+    font-size: 3.25rem;
     font-style: italic;
     margin-top: 5px;
     padding-bottom: 5px;
@@ -290,8 +295,8 @@ $terror-red: #BD2C00;
 
   h4 {
     display: inline-block;
-    font-size: 4.8rem;
-    line-height: 5.6rem;
+    font-size: 3rem;
+    line-height: 3.5rem;
     font-weight: bold;
   }
 
@@ -303,8 +308,8 @@ $terror-red: #BD2C00;
 
   p {
     display: inline;
-    font-size: 4.8rem;
-    line-height: 5.6rem;
+    font-size: 3rem;
+    line-height: 3.5rem;
     margin: 5px auto
   }
 
@@ -315,8 +320,8 @@ $terror-red: #BD2C00;
   a {
     color: $terror-light-green;
     display: inline-block;
-    font-size: 3.6rem;
-    line-height: 4.4rem;
+    font-size: 2.25rem;
+    line-height: 2.75rem;
     font-weight: bold;
     margin-top: 10px;
     text-decoration: none;

--- a/app/views/games/human_control.html.erb
+++ b/app/views/games/human_control.html.erb
@@ -1,62 +1,55 @@
 <div id="admin">
   <h1>Human Control</h1>
 
-  <h3 class="clearfix">
-    <div class="half-width">PR Changes From Round: <%= @last_round %></div>
-    <div class="half-width">PR By Country</div>
-  </h3>
-
-  <section class="clearfix">
-    <div class="half-width">
-      <p>
-        <em>
-          PR effects collected on turn <%= @current_round %> will be distributed to teams halfway
-          through turn <%= @current_round + 1 %> along with credits.  These credits will then be usable in turn <%= @current_round + 2%>.
-        </em>
-      </p>
-      <table class="unpr">
-        <thead>
-          <tr>
-            <th >Country</th>
-            <th >PR Change</th>
-            <th >Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @pr_amounts.each do |data, value| %>
-            <tr>
-              <td><%= data %></td>
-              <td><%= value %></td>
-              <td><%= link_to "Details", country_pr_status_path(data), :class => "button-input" %></td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-    <div class="half-width">
-      <%= render 'layouts/country_pr_menu' %>
-      <table class="unpr">
+  <h3>PR Changes from Round: <%= @last_round %></h3>
+  <section>
+    <p><em>PR effects collected on turn <%= @current_round %> will be
+    distributed to teams halfway through turn <%= @current_round + 1 %> along
+    with credits.  These credits will then be usable in turn
+    <%= @current_round + 2%>.</em></p>
+    <table class="unpr">
+      <thead>
         <tr>
-          <th>Country</th>
-          <th>Distributed Round <%= @current_round %> Income</th>
-          <th>Distributed Round <%= @current_round %> Credits</th>
-          <th>Bonus Reserves Distributed for Round <%= @current_round %></th>
-          <th>Distributed Recurring Reserves</th>
+          <th >Country</th>
+          <th >PR Change</th>
+          <th >Details</th>
         </tr>
-        <% @incomes.each do |income| %>
+      </thead>
+      <tbody>
+        <% @pr_amounts.each do |data, value| %>
           <tr>
-            <td><%= income.team_name %></td>
-            <td><%= income.amount%></td>
-            <td><%= @income_values[income.team_name][income.amount-1]%></td>
-            <td><%= @game.bonus_credits.where(team: income.team, round: @current_round, recurring: false).sum(:amount) %></td>
-            <td><%= @game.bonus_credits.where('team_id = ? AND round <= ? AND recurring = TRUE', income.team_id, @current_round).sum(:amount) %></td>
+            <td><%= data %></td>
+            <td><%= value %></td>
+            <td><%= link_to "Details", country_pr_status_path(data), :class => "button-input" %></td>
           </tr>
-          <% end %>
-      </table>
-      <%= link_to "Income Index" , incomes_path(),:class => "button-input" %>
-      <%= link_to "Add Bonus Reserves", new_bonus_credit_path, :class => 'button-input' %>
-      <%= link_to "Bonus Reserves Index", bonus_credits_path, :class => "button-input" %>
-    </div>
+        <% end %>
+      </tbody>
+    </table>
+  </section>
+
+  <%= render 'layouts/country_pr_menu' %>
+  <section>
+    <table class="unpr">
+      <tr>
+        <th>Country</th>
+        <th>Distributed Round <%= @current_round %> Income</th>
+        <th>Distributed Round <%= @current_round %> Credits</th>
+        <th>Bonus Reserves Distributed for Round <%= @current_round %></th>
+        <th>Distributed Recurring Reserves</th>
+      </tr>
+      <% @incomes.each do |income| %>
+        <tr>
+          <td><%= income.team_name %></td>
+          <td><%= income.amount%></td>
+          <td><%= @income_values[income.team_name][income.amount-1]%></td>
+          <td><%= @game.bonus_credits.where(team: income.team, round: @current_round, recurring: false).sum(:amount) %></td>
+          <td><%= @game.bonus_credits.where('team_id = ? AND round <= ? AND recurring = TRUE', income.team_id, @current_round).sum(:amount) %></td>
+        </tr>
+        <% end %>
+    </table>
+    <%= link_to "Income Index" , incomes_path(),:class => "button-input" %>
+    <%= link_to "Add Bonus Reserves", new_bonus_credit_path, :class => 'button-input' %>
+    <%= link_to "Bonus Reserves Index", bonus_credits_path, :class => "button-input" %>
   </section>
 
   <h3>Bulk Human PR Creation</h3>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -18,8 +18,8 @@
         <tr>
           <td><%= team.id %></td>
           <td><%= team.team_name %></td>
-          <td><%= link_to 'Edit', edit_team_path(team) %></td>
-          <td><%= link_to 'Destroy', team, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+          <td><%= link_to 'Edit', edit_team_path(team), :class => 'button-input' %></td>
+          <td><%= link_to 'Destroy', team, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'button-input' %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -24,8 +24,8 @@
           <td><%= user.role %></td>
           <td><% if user.role === 'Player' %><%= user.team.team_name %><% end %></td>
           <td><% if user.role === 'Player' %><%= user.team_role.role_display_name %><% end %></td>
-          <td><%= link_to 'Edit', edit_user_path(user) %></td>
-          <td><%= link_to 'Destroy', user, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+          <td><%= link_to 'Edit', edit_user_path(user), :class => 'button-input' %></td>
+          <td><%= link_to 'Destroy', user, method: :delete, data: { confirm: 'Are you sure?' }, :class => 'button-input' %></td>
         </tr>
       <% end %>
     </tbody>


### PR DESCRIPTION
Basically I changed the font base to be 100% instead of 62.5% because of the focus on Mobile and it created a situation where all the previously set fonts were scaled up by 37.5%. I've sized them down manually to an approximate size as a "quick fix", but they should be standardized at some point in the future (On my ever-growing To Do list).

### Before
<img width="648" alt="screen shot 2016-06-12 at 6 22 09 pm" src="https://cloud.githubusercontent.com/assets/1640601/15994157/a7684874-30ca-11e6-9253-c7e8d265ee62.png">

### After

<img width="648" alt="screen shot 2016-06-12 at 6 20 27 pm" src="https://cloud.githubusercontent.com/assets/1640601/15994154/7df4adca-30ca-11e6-83d1-f6cb4f796f9e.png">
