### PR TITLE
Zjs/refactor pr logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development, :test do
   gem 'spring'
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'pry-rails'
   # Use sqlite3 as the database for Active Record
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -229,6 +231,7 @@ DEPENDENCIES
   pg
   pluck_to_hash
   pry
+  pry-rails
   rails (= 4.2)
   rails_12factor
   roo
@@ -239,3 +242,6 @@ DEPENDENCIES
   turbolinks
   twitter
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.10.6

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -136,7 +136,9 @@ class GamesController < ApplicationController
   def update_round
     @game = current_game
     @game.round = params[:game][:round]
+    @game.update_income_levels
     @game.save
+
     redirect_to admin_control_path
   end
 

--- a/app/controllers/public_relations_controller.rb
+++ b/app/controllers/public_relations_controller.rb
@@ -157,4 +157,5 @@ class PublicRelationsController < ApplicationController
       params[:public_relation].permit(:source, :country, :description, :round, :pr_amount, :team)
     end
 
+
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -65,14 +65,13 @@ class Game < ActiveRecord::Base
     teams.each do |team|
       turn_0 = calculate_income_level(self.public_relations.where(round: 0).where(team: team).sum(:pr_amount) || 0)
       if (round > 1)
-        amount = self.public_relations.where('round < ?', [round - 1, 1].max).where(team: team).group(:round).sum(:pr_amount).reduce(6 + turn_0) do |memo, arr|
-          round, pr_diff = arr
-          return [memo + calculate_income_level(pr_diff), 0].max
+        amount = self.public_relations.where('round < ? and round > 0', [round - 1, 0].max).where(team: team).group(:round).sum(:pr_amount).reduce(6 + turn_0) do |memo, arr|
+          _, pr_diff = arr
+          [memo + calculate_income_level(pr_diff), 0].max
         end
       else
         amount = 6 + turn_0
       end
-
       next_income = Income.find_or_create_by(round: round + 1, team: team, game: self)
       next_income.amount = amount
       next_income.save()

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -63,7 +63,7 @@ class Game < ActiveRecord::Base
     
     teams = Team.all_without_incomes
     teams.each do |team|
-      amount = self.public_relations.where('round < ?', [round - 2, 0].max).where(team: team).group(:round).sum(:pr_amount).reduce(3) do |memo, arr|
+      amount = self.public_relations.where('round < ?', [round - 1, 0].max).where(team: team).group(:round).sum(:pr_amount).reduce(6) do |memo, arr|
         round, pr_diff = arr
         return [memo + calculate_income_level(pr_diff), 0].max
       end
@@ -106,8 +106,8 @@ class Game < ActiveRecord::Base
   private
 
   def calculate_income_level(pr)
-    # PR > 4, change Income +1
-    # PR < -1 and PR < -3, change Income -1
+    # PR >= 4, change Income +1
+    # PR <= -1 and PR >= -3, change Income -1
     # PR < -3, change Income -2
     if pr >= 4
       return 1
@@ -115,6 +115,8 @@ class Game < ActiveRecord::Base
       return -1
     elsif pr < -3
       return -2
+    else
+      return 0
     end
   end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -63,9 +63,14 @@ class Game < ActiveRecord::Base
     
     teams = Team.all_without_incomes
     teams.each do |team|
-      amount = self.public_relations.where('round < ?', [round - 1, 0].max).where(team: team).group(:round).sum(:pr_amount).reduce(6) do |memo, arr|
-        round, pr_diff = arr
-        return [memo + calculate_income_level(pr_diff), 0].max
+      turn_0 = calculate_income_level(self.public_relations.where(round: 0).where(team: team).sum(:pr_amount) || 0)
+      if (round > 1)
+        amount = self.public_relations.where('round < ?', [round - 1, 1].max).where(team: team).group(:round).sum(:pr_amount).reduce(6 + turn_0) do |memo, arr|
+          round, pr_diff = arr
+          return [memo + calculate_income_level(pr_diff), 0].max
+        end
+      else
+        amount = 6 + turn_0
       end
 
       next_income = Income.find_or_create_by(round: round + 1, team: team, game: self)

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,8 +8,8 @@ default: &default
   adapter: postgresql
   pool: 5
   timeout: 5000
-  username: root
-  password: root
+  username: zstayman
+  password:
 
 development:
   <<: *default


### PR DESCRIPTION
Changed some handling of PR Logic to ensure consistency. 

- Moved Update PR Levels to after game round update
- Changed `game#update_income_levels` to recalculate from the beginning of the game to allow it to catch changes in history
- call `game#update_income_levels` when round is reset